### PR TITLE
updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "through2": "~0.4.1"
   },
   "devDependencies": {
-    "coveralls": "~2.8.0",
-    "should": "~2.1.0",
-    "sinon": "~1.8.1",
-    "mocha-lcov-reporter": "0.0.1",
+    "coveralls": "^2.11.0",
+    "should": "4.0.0",
+    "sinon": "^1.10.0",
+    "mocha-lcov-reporter": "^0.0.1",
     "event-stream": "~3.1.0",
-    "mocha": "~1.17.1",
-    "istanbul": "~0.2.4",
-    "jshint": "~2.4.3"
+    "mocha": "^1.21.1",
+    "istanbul": "^0.3.0",
+    "jshint": "^2.5.0"
   },
   "engines": {
     "node": ">=0.10.0",


### PR DESCRIPTION
Please merge this change. The coveralls version in the current package does not properly handle relative paths, so it gives coveralls the full travis build path.
