### PR TITLE
Add filepath option as parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@ var through = require('through2'),
   gutil = require('gulp-util'),
   coveralls = require('coveralls');
 
-module.exports = function() {
+module.exports = function (gulpOptions) {
+  gulpOptions = gulpOptions || { filepath : '.' };
+
+
   return through.obj(function(file, enc, callback) {
     var stream = this;
 
@@ -24,7 +27,7 @@ module.exports = function() {
 
     function sendToCoveralls(input, done) {
       coveralls.getBaseOptions(function(err, options){
-        options.filepath = '.';
+        options.filepath = gulpOptions.filepath;
         coveralls.convertLcovToCoveralls(input, options, function(err, postData){
           handleError(done, err);
           coveralls.sendToCoveralls(postData, function(err, response, body){


### PR DESCRIPTION
I had a use case where I needed to modify the value of options.filepath.
So I passed this value as a parameter of gulp-coveralls.

Usage:

``` javascript
gulp.src('/**/lcov.info')
.pipe(coveralls({filepath:"build"}));
```
